### PR TITLE
Fixed suggestions not showing

### DIFF
--- a/dmenu-wl_run
+++ b/dmenu-wl_run
@@ -1,2 +1,2 @@
 #!/bin/sh
-dmenu_path | dmenu-wl "$@" | ${SHELL:-"/bin/sh"} &
+dmenu-wl_path | dmenu-wl "$@" | ${SHELL:-"/bin/sh"} &


### PR DESCRIPTION
The suggestions for which executable to run were not showing, requiring
the user to type in the exact name of the executable. This depreciated
the user experience when using the dmenu.
In this commit I fixed just that. The suggestions are showing again and
you can select them with the arrowkeys, just as you would expect them
to.

The problem was a naming issue in the `dmenu-wl_run` script. There the
executable for finding all executables was named `dmenu_path`, while in
the `meson.build` file this executable was named `dmenu-wl_path`. All I
needed to do was adapting the name in the script.