### PR TITLE
Fix anchors to make exclusive zone work.

### DIFF
--- a/draw.c
+++ b/draw.c
@@ -537,6 +537,7 @@ void dmenu_init_panel(struct dmenu_panel *panel, int32_t height, bool bottom) {
 								   panel->monitor->logical_width, panel->height);
 	zwlr_layer_surface_v1_set_anchor(panel->surface.layer_surface,
 									 ZWLR_LAYER_SURFACE_V1_ANCHOR_LEFT |
+									 ZWLR_LAYER_SURFACE_V1_ANCHOR_RIGHT |
 									 (bottom ? ZWLR_LAYER_SURFACE_V1_ANCHOR_BOTTOM
 									  : ZWLR_LAYER_SURFACE_V1_ANCHOR_TOP));
 


### PR DESCRIPTION
Quoting the spec:
> A positive value is only meaningful if the surface is anchored to one edge or an edge and both perpendicular edges. If the surface is not anchored, anchored to only two perpendicular edges (a corner), anchored to only two parallel edges or anchored to all edges, a positive value will be treated the same                                                                                                                                                                                                                                              as zero.

This PR adds the opposite anchor (RIGHT) to fulfil this condition.