### PR TITLE
GCC-10 multiple definition progname

### DIFF
--- a/dmenu.c
+++ b/dmenu.c
@@ -40,6 +40,7 @@ struct {
 	int32_t scroll_right;
 } window_config;
 
+const char *progname;
 
 static uint32_t color_bg = 0x222222ff;
 static uint32_t color_fg = 0xbbbbbbff;

--- a/draw.h
+++ b/draw.h
@@ -103,4 +103,4 @@ void eprintf(const char *fmt, ...);
 void weprintf(const char *fmt, ...);
 int32_t round_to_int(double val);
 
-const char *progname;
+extern const char *progname;


### PR DESCRIPTION
My gcc-10 doesn't like that the draw.h defines progname and then
includes it in two .c files. So we define it only in dmenu.c