### PR TITLE
support cross-compilation

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -26,7 +26,7 @@ pangocairo          = dependency('pangocairo')
 rt                  = cc.find_library('rt')
 wayland_client      = dependency('wayland-client')
 wayland_protos      = dependency('wayland-protocols')
-wayland_scanner_dep = dependency('wayland-scanner')
+wayland_scanner_dep = dependency('wayland-scanner', native: true)
 wayland_scanner     = find_program(
   wayland_scanner_dep.get_pkgconfig_variable('wayland_scanner')
 )


### PR DESCRIPTION
By marking wayland-scanner as native dependency.

I've verified that this builds by applying this patch on nixpkgs and running the build recipe.

Just for reference, this is the change applied to nixpkgs:

```diff
diff --git a/pkgs/applications/misc/dmenu/wayland.nix b/pkgs/applications/misc/dmenu/wayland.nix
index 8d77588ce8f..41ac43a4ff4 100644
--- a/pkgs/applications/misc/dmenu/wayland.nix
+++ b/pkgs/applications/misc/dmenu/wayland.nix
@@ -1,5 +1,5 @@
 { lib, stdenv, fetchFromGitHub, meson, ninja, cairo, pango, pkg-config, wayland-protocols
-, glib, wayland, libxkbcommon, makeWrapper
+, glib, wayland, libxkbcommon, makeWrapper, wayland-scanner
 }:
 
 stdenv.mkDerivation rec {
@@ -15,9 +15,15 @@ stdenv.mkDerivation rec {
 
   outputs = [ "out" "man" ];
 
-  nativeBuildInputs = [ meson ninja pkg-config makeWrapper ];
+  depsBuildBuild = [ pkg-config ];
+  nativeBuildInputs = [ meson ninja pkg-config makeWrapper wayland-scanner ];
   buildInputs = [ cairo pango wayland-protocols glib wayland libxkbcommon ];
 
+  postPatch = ''
+    substituteInPlace meson.build \
+      --replace "dependency('wayland-scanner')" "dependency('wayland-scanner', native: true)"
+  '';
+
   postInstall = ''
     wrapProgram $out/bin/dmenu-wl_run \
       --prefix PATH : $out/bin
```

(which is basically the same as this patch).

I did not verify if the binary runs properly, but it at least builds this way and the meson.build script should be more correct for the cross-compilation usecase.