### PR TITLE
docs: current selection is not an X selection

### DIFF
--- a/dmenu-wl.1
+++ b/dmenu-wl.1
@@ -120,6 +120,6 @@ success.
 Exit without selecting an item, returning failure.
 .TP
 .B Control\-y
-Paste the current X selection into the input field.
+Paste the current selection into the input field.
 .SH SEE ALSO
 .BR dwm (1)


### PR DESCRIPTION
I presume the mention of "X" here was a mistake, as Wayland would be handling the selection.