### PR TITLE
Add explicit info that Gnome and KDE are not supported

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,7 @@ Other TODO items:
 ## Requirements
 Requires a compositor which implements wlr-layer-shell and xdg-output
 protocols. Basically this means a wlroots-based compositor is needed.
+Gnome and KDE are therefore [not supported](https://github.com/nyyManni/dmenu-wayland/issues/16).
 Tested with sway 1.0.
 
 Required libraries (and headers):


### PR DESCRIPTION
The readme does mention the requirement for wlroots, but it could be more explicit about not supporting Gnome and KDE (at this time). 

Adding a remark in the readme and linking to the issue. 